### PR TITLE
add scrollTrigger option. Allow user to provide her own triggering eleme...

### DIFF
--- a/src/jquery.scrollUp.js
+++ b/src/jquery.scrollUp.js
@@ -18,6 +18,7 @@
         scrollTitle = (o.scrollTitle) ? o.scrollTitle : o.scrollText,
 
         // Create element
+		$self;
 		if (o.scrollTrigger) {
 			$self = $(o.scrollTrigger);
 		} else {
@@ -30,7 +31,7 @@
         $self.appendTo('body');
 
         // If not using an image display text
-        if (!o.scrollImg) {
+        if (!(o.scrollImg || o.scrollTrigger)) {
             $self.html(o.scrollText);
         }
 


### PR DESCRIPTION
This feature allows users to pass a custom triggering element to scrollUp.

It's a feature I needed for a project I'm working on.

Example Usage: (use a FontAwesome glyph as link icon)

```
$(function () {
  var scrollName = 'scrollUp'
    , scrollText = 'Scroll to top'
    , $icon = $('<i class="fa fa-arrow-up"/>')
    , $template = $('<a/>', {
        id: scrollName,
        href: '#top',
        title: scrollText,
      }).append($icon)
  ;

  $.scrollUp({
    scrollName: scrollName, // Element ID
    topDistance: '300', // Distance from top before showing element (px)
    topSpeed: 300, // Speed back to top (ms)
    animation: 'slide', // Fade, slide, none
    animationInSpeed: 200, // Animation in speed (ms)
    animationOutSpeed: 200, // Animation out speed (ms)
    scrollTrigger: $template, // Custom triggering element
    scrollImg: true,
    scrollText: scrollText, // Text for element
    activeOverlay: false, // Set CSS color to display scrollUp active point, e.g '#00FFFF'
  });
});
```
