### PR TITLE
bugfix gulp watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,5 +35,5 @@ gulp.task('default', function() {
 
 // Watch
 gulp.task('watch', function() {
-  gulp.watch(config.src, ['default']);
+  gulp.watch('src/*.js', ['default']);
 });


### PR DESCRIPTION
I get an error when I run `gulp watch` task so I rewrite the code.

![8253194b-b096-42e6-a179-37640256e353](https://cloud.githubusercontent.com/assets/8475099/17503004/d75b617a-5e1e-11e6-8d8b-6a396d7edf1f.png)
